### PR TITLE
docker: add fakeroot package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,9 @@ RUN pacman -D --asdeps $(pacman -Qqe) && \
         pacman -Rns $unused_pkgs --noconfirm --noprogressbar ; \
     fi )
 
+#FIXME: yay should depend on fakeroot
+RUN pacman -S fakeroot --noprogressbar --noconfirm --needed
+
 # Remove cache and update trusted certs
 RUN rm -rf /var/cache/pacman/pkg/* && \
     rm -rf /var/lib/pacman/sync/* && \


### PR DESCRIPTION
Package yay doesn't depend on it, but fakeroot is needed when yay is packaging
an AUR PKGBUILD.

Signed-off-by: Luís Ferreira <contact@lsferreira.net>